### PR TITLE
slew the this beast

### DIFF
--- a/urbit/app/smol.hoon
+++ b/urbit/app/smol.hoon
@@ -30,23 +30,20 @@
 --
 ::
 |_  [bol=bowl:gall ~]
-:: "this" is a shorthand for returning the state.
-++  this  .
-::
 ++  bound
   |=  [wir=wire success=? binding=binding:eyre]
-  ^-  (quip effect _this)
-  [~ this]
+  ^-  (quip effect _+>.$)
+  [~ +>.$]
 :: The prep arm sets up the application when it first starts up or when the source code is updated.
 :: We poke the launch app, which serves the tiles in the Modulo interface, with the app name, 
 :: the unique path to subscribe to our app (where to send JSON to the tile) and the path the tile's served on.
 :: The launch app expects window.[appNameTile] to contain the JS class for the tile (see tile/tile.js:47).
 ++  prep
   |=  old=(unit ~)
-  ^-  (quip effect _this)
+  ^-  (quip effect _+>.$)
   =/  launcha
     [%launch-action [%%APPNAME% /%APPNAME%tile '/~%APPNAME%/js/tile.js']]
-  :_  this
+  :_  +>.$
   :~
     [ost.bol %connect / [~ /'~%APPNAME%'] %%APPNAME%]
     [ost.bol %poke /%APPNAME% [our.bol %launch] launcha]
@@ -56,13 +53,13 @@
 :: In this example, it sends "our.bol" (our ship's name) as a JSON string to our React.js file.
 :: If you have nothing to send to the tile -- if the tile has nothing to receive from your ship --
 :: you'll want to "bunt" (sending a blank with *) the JSON: delete line 62 and replace line 63 with
-:: [[ost.bol %diff %json *json]~ this]
+:: [[ost.bol %diff %json *json]~ +>.$]
 ::
 ++  peer-%APPNAME%tile
   |=  pax=path
-  ^-  (quip effect _this)
+  ^-  (quip effect _+>.$)
   =/  jon=json  [%s (crip (scow %p our.bol))]
-  [[ost.bol %diff %json jon]~ this]
+  [[ost.bol %diff %json jon]~ +>.$]
 
 :: When this arm is called from this application, 
 :: it sends effects to every subscriber of this application's unique path.
@@ -74,9 +71,9 @@
   [bone %diff %json jon]
 ::
 ++  poke-handle-http-request
-  %-  (require-authorization:app ost.bol effect this)
+  %-  (require-authorization:app ost.bol effect .)
   |=  =inbound-request:eyre
-  ^-  (quip effect _this)
+  ^-  (quip effect _+>.$)
   =/  request-line  (parse-request-line url.request.inbound-request)
   =/  back-path  (flop site.request-line)
   =/  name=@t
@@ -86,9 +83,9 @@
     i.back-path
   ::
   ?~  back-path
-    [[ost.bol %http-response not-found:app]~ this]
+    [[ost.bol %http-response not-found:app]~ +>.$]
   ?:  =(name 'tile')
-    [[ost.bol %http-response (js-response:app tile-js)]~ this]
-  [[ost.bol %http-response not-found:app]~ this]
+    [[ost.bol %http-response (js-response:app tile-js)]~ +>.$]
+  [[ost.bol %http-response not-found:app]~ +>.$]
 ::
 --

--- a/urbit/app/smol.hoon
+++ b/urbit/app/smol.hoon
@@ -58,7 +58,7 @@
 ++  peer-%APPNAME%tile
   |=  pax=path
   ^-  (quip effect _+>.$)
-  =/  jon=json  [%s (crip (scow %p our.bol))]
+  =/  jon=json  [%s (scot %p our.bol)]
   [[ost.bol %diff %json jon]~ +>.$]
 
 :: When this arm is called from this application, 


### PR DESCRIPTION
this arms are a bad smell because they end up being [0 1] in nock which is a
non free computation and often not a major improvement in readability over
+>.$ to non hoon novices. =* could be used in ++poke-handle-http-request to
avoid the spelling the subject two different ways in the same block of code
problem but meh.