### PR TITLE
full: better layout of the content div

### DIFF
--- a/full/src/css/custom.css
+++ b/full/src/css/custom.css
@@ -137,3 +137,29 @@ h2 {
     color: #4d4d4d;
   }
 }
+
+/* responsive */
+
+@media all and (max-width: 34.375em) {
+  .h-100-minus-40-s {
+    height: calc(100% - 40px);
+  }
+}
+
+@media all and (min-width: 34.375em) and (max-width: 46.875em) {
+  .h-100-minus-40-m {
+    height: calc(100% - 40px);
+  }
+}
+
+@media all and (min-width: 46.875em) and (max-width: 60em) {
+  .h-100-minus-40-l {
+    height: calc(100% - 40px);
+  }
+}
+
+@media all and (min-width: 60em) {
+  .h-100-minus-40-xl {
+    height: calc(100% - 40px);
+  }
+}

--- a/full/src/js/components/root.js
+++ b/full/src/js/components/root.js
@@ -17,7 +17,7 @@ export class Root extends Component {
         <HeaderBar/>
         <Route exact path="/~%APPNAME%" render={ () => {
           return (
-            <div className="cf w-100 flex flex-column pa4 ba-m ba-l ba-xl b--gray2 br1 h-100 h-100-minus-40-m h-100-minus-40-l h-100-minus-40-xl f9 white-d">
+            <div className="cf w-100 flex flex-column pa4 ba-m ba-l ba-xl b--gray2 br1 h-100 h-100-minus-40-s h-100-minus-40-m h-100-minus-40-l h-100-minus-40-xl f9 white-d overflow-x-hidden">
               <h1 className="mt0 f8 fw4">%APPNAME%</h1>
               <p className="lh-copy measure pt3">Welcome to your Landscape application.</p>
               <p className="lh-copy measure pt3">To get started, edit <code>src/index.js</code> or <code>%APPNAME%.hoon</code> and <code>|commit %home</code> on your Urbit ship to see your changes.</p>


### PR DESCRIPTION
This PR doesn't have the contents of https://github.com/urbit/create-landscape-app/pull/25 but I think it can be pulled cleanly after that one.

When you have screen width such that `h-100-minus-40-s` comes into play the layout breaks (the content border disappears and some margin or padding in the header is lost), but that was true before so I won't worry about it.