### PR TITLE
Change %launch wire to unique name

### DIFF
--- a/urbit/app/smol.hoon
+++ b/urbit/app/smol.hoon
@@ -17,7 +17,7 @@
 ++  on-init
   ^-  (quip card:agent:gall _this)
   =/  launcha
-    [%launch-action !>([%add %%APPNAME% /tile '/~%APPNAME%/js/tile.js'])]
+    [%launch-action !>([%add %%APPNAME% /%APPNAME%tile '/~%APPNAME%/js/tile.js'])]
   :_  this
   :~  [%pass / %arvo %e %connect [~ /'~%APPNAME%'] %%APPNAME%]
       [%pass /%APPNAME% %agent [our.bowl %launch] %poke launcha]
@@ -53,7 +53,7 @@
   ^-  (quip card:agent:gall _this)
   ?:  ?=([%http-response *] path)
     `this
-  ?.  =(/tile path)
+  ?.  =([%APPNAME%tile *] path)
     (on-watch:def path)
   [[%give %fact ~ %json !>(*json)]~ this]
 ::


### PR DESCRIPTION
I believe the wire we send to %launch should be unique, since it is local to launch, not our app.
@liam-fitzgerald @loganallenc confirm?