### PR TITLE
full: remove ginormous h2 in custom.css

### DIFF
--- a/full/src/css/custom.css
+++ b/full/src/css/custom.css
@@ -18,13 +18,6 @@ textarea, select, input, button {
   background-color: #fff;
 }
 
-
-h2 {
-  font-size: 32px;
-  line-height: 48px;
-  font-weight: bold;
-}
-
 .body-regular {
   font-size: 16px;
   line-height: 24px;


### PR DESCRIPTION
before:
<img width="487" alt="h2-before" src="https://user-images.githubusercontent.com/15039850/80821720-e61d6080-8b9e-11ea-9c0f-5384c4fff36b.png">

after:
<img width="485" alt="h2-after" src="https://user-images.githubusercontent.com/15039850/80821756-f7666d00-8b9e-11ea-922a-ba1f48934106.png">
