### PR TITLE
Change launch wire from symbol to path in tile template

### DIFF
--- a/urbit/app/smol.hoon
+++ b/urbit/app/smol.hoon
@@ -53,7 +53,7 @@
   ^-  (quip card:agent:gall _this)
   ?:  ?=([%http-response *] path)
     `this
-  ?.  =([%APPNAME%tile *] path)
+  ?.  =([/%APPNAME%tile *] path)
     (on-watch:def path)
   [[%give %fact ~ %json !>(*json)]~ this]
 ::


### PR DESCRIPTION
I found I needed to change this or else I'd run into a `-find.apptile` error on launch.