### PR TITLE
install.js: delete .DS_Store before MoveDir() in setupFull()

### DIFF
--- a/install.js
+++ b/install.js
@@ -44,7 +44,7 @@ prompt.get([{
 
 const setupTile = function (result) {
     deleteFolderRecursive('full')
-    let deHyphenatedName = result.appName.indexOf('-') > -1 ? result.appName.replace(/-/g, "") : result.appName
+    let deHyphenatedName = result.appName.replace(/-/g, '')
     fs.renameSync('urbit/app/smol.hoon', 'urbit/app/' + deHyphenatedName + '.hoon')
     // Make a copy of the name without hyphens for the JS naming.
     let capitalisedAppName = deHyphenatedName.charAt(0).toUpperCase() + deHyphenatedName.slice(1)
@@ -168,7 +168,8 @@ const setupFull = function (result) {
     deleteFolderRecursive('tile')
     deleteFolderRecursive('urbit')
     fs.unlinkSync('gulpfile.js')
-    let deHyphenatedName = result.appName.indexOf('-') > -1 ? result.appName.replace(/-/g, "") : result.appName
+    fs.access('.DS_Store', (err) => { if (!err) fs.unlinkSync('.DS_Store') })
+    let deHyphenatedName = result.appName.replace(/-/g, '')
     moveDir('full', './', function() {
         fs.renameSync('urbit/app/smol.hoon', 'urbit/app/' + deHyphenatedName + '.hoon')
         fs.renameSync('urbit/app/smol/', 'urbit/app/' + deHyphenatedName)
@@ -188,4 +189,5 @@ const setupFull = function (result) {
         }
         replace(appNameOptions).then(changedFiles => console.log(changedFiles)).catch(err => console.error(err))
     })
+    console.log("All done! Happy hacking.")
 }


### PR DESCRIPTION
If you clone the repository and do macOS Finder operations that create `.DS_Store` _and_ `full/.DS_Store` you get this when you `npm start`:
```
What's the name of your application? Lowercase and no spaces, please.: test
Is your app just a tile, or a full application? (tile/full): full
Where is your Urbit pier's desk located? For example, /Users/dev/zod/home: /
(node:74511) UnhandledPromiseRejectionWarning: Error: dest already exists.
    at /xxx/create-landscape-app/node_modules/fs-extra/lib/move/move.js:41:31
    at /xxx/create-landscape-app/node_modules/universalify/index.js:23:46
```
The `dest` is `./.DS_Store`.  This PR deletes it, if it exists.  I tested all 4 combinations of the existence of `.DS-Store` and `full/.DS_Store`.

It also simplifies the `deHyphenatedName` assignment.  I tested by creating a full app with a non-hyphenated name, and a tile app with a hyphenated name.  I also ran this code:
```
const name1 = 'hello-goodbye--z---'
console.log(name1)
console.log(name1.indexOf('-'))
console.log(name1.replace(/-/g, ''))
const name2 = 'abcdefg'
console.log(name2)
console.log(name2.indexOf('-'))
console.log(name2.replace(/-/g, ''))
```
```
hello-goodbye--z---
5
hellogoodbyez
abcdefg
-1
abcdefg
```

I also added an "All done" message to `setupFull()` to match `setupTile()`.