### PR TITLE
UI bug: Prepend zeros in @ux -> hex color

### DIFF
--- a/full/ui/src/components/AppTile.tsx
+++ b/full/ui/src/components/AppTile.tsx
@@ -5,7 +5,12 @@ function normalizeUrbitColor(color: string): string {
   if (color.startsWith('#')) {
     return color;
   }
-  return `#${color.slice(2).replace('.', '').toUpperCase()}`;
+  var colbytes:string = `${color.slice(2).replace('.', '').toUpperCase()}`;
+
+  while(colbytes.length < 6) {
+    colbytes = "0" + colbytes;
+  }
+  return "#" + colbytes;
 }
 
 export const AppTile = ({ image, color }: Charge) => {


### PR DESCRIPTION
arvo @ux does not support leading 0s
```
blue  = #0000ff = 0xff   != #ff
green = #00ff00 = 0xff00 != #ff00
```

so leading zeros should be prepended when interpreting @ux as a hex color.

-----

Tested using the tiles in the default create-landscape-app & the above color codes in desk.docket-0.
They get correct color with this change, and an incorrect (grey / white) color without.