### PR TITLE
Update skeleton dependencies

### DIFF
--- a/js/ui/package.json
+++ b/js/ui/package.json
@@ -10,15 +10,15 @@
   "dependencies": {
     "@urbit/api": "^2.0.0",
     "@urbit/http-api": "^2.0.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@holium/vite-plugin-urbit": "^0.8.0",
-    "@vitejs/plugin-react-refresh": "^1.3.1",
-    "autoprefixer": "^10.4.12",
-    "postcss": "^8.4.18",
-    "tailwindcss": "^3.2.1",
-    "vite": "^4.1.0"
+    "@urbit/vite-plugin-urbit": "^1.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.2",
+    "vite": "^4.3.9"
   }
 }

--- a/js/ui/package.json
+++ b/js/ui/package.json
@@ -8,8 +8,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@urbit/api": "^2.0.0",
-    "@urbit/http-api": "^2.0.0",
+    "@urbit/api": "^2.3.0",
+    "@urbit/http-api": "^2.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/js/ui/src/main.jsx
+++ b/js/ui/src/main.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { App } from './app';
 import './index.css';
 
-ReactDOM.render(
+const container = document.getElementById('app');
+createRoot(container).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('app')
+  </React.StrictMode>
 );

--- a/js/ui/vite.config.js
+++ b/js/ui/vite.config.js
@@ -1,6 +1,6 @@
 import { loadEnv, defineConfig } from 'vite';
-import reactRefresh from '@vitejs/plugin-react-refresh';
-import { urbitPlugin } from '@holium/vite-plugin-urbit';
+import reactRefresh from '@vitejs/plugin-react';
+import { urbitPlugin } from '@urbit/vite-plugin-urbit';
 
 // https://vitejs.dev/config/
 export default ({ mode }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/create-landscape-app",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Get started with a Landscape application.",
   "main": "node install.js",
   "bin": "install.js",

--- a/ts/ui/package.json
+++ b/ts/ui/package.json
@@ -12,18 +12,17 @@
   "dependencies": {
     "@urbit/api": "^2.0.0",
     "@urbit/http-api": "^2.0.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/react": "^17.0.0",
-    "@types/react-dom": "^17.0.0",
-    "@holium/vite-plugin-urbit": "^0.8.0",
-    "@vitejs/plugin-react-refresh": "^1.3.1",
-    "autoprefixer": "^10.4.12",
-    "postcss": "^8.4.18",
-    "tailwindcss": "^3.2.1",
-    "typescript": "^4.3.2",
-    "vite": "^4.1.0"
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@urbit/vite-plugin-urbit": "^1.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.2",
+    "vite": "^4.3.9"
   }
 }

--- a/ts/ui/package.json
+++ b/ts/ui/package.json
@@ -10,8 +10,8 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@urbit/api": "^2.0.0",
-    "@urbit/http-api": "^2.0.0",
+    "@urbit/api": "^2.3.0",
+    "@urbit/http-api": "^2.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/ts/ui/src/main.tsx
+++ b/ts/ui/src/main.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { App } from './app';
 import './index.css';
 
-ReactDOM.render(
+const container = document.getElementById('app');
+createRoot(container).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('app')
+  </React.StrictMode>
 );

--- a/ts/ui/vite.config.ts
+++ b/ts/ui/vite.config.ts
@@ -1,6 +1,6 @@
 import { loadEnv, defineConfig } from 'vite';
-import reactRefresh from '@vitejs/plugin-react-refresh';
-import { urbitPlugin } from '@holium/vite-plugin-urbit';
+import reactRefresh from '@vitejs/plugin-react';
+import { urbitPlugin } from '@urbit/vite-plugin-urbit';
 
 // https://vitejs.dev/config/
 export default ({ mode }) => {


### PR DESCRIPTION
- Upgrade to React 18
- Replace @holium/vite-plugin-urbit with @urbit/vite-plugin-urbit
- Replace deprecated @vitejs/plugin-react-refresh with @vitejs/plugin-react
- Refresh all dependencies to denote the latest versions in package.json